### PR TITLE
fix: 解决CDN方式时process is not defined问题

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,9 @@ export default defineConfig({
       include: [path.resolve(__dirname, "locales/**")]
     })
   ],
+  define: {
+    "process.env": process.env
+  },
   server: {
     host: "0.0.0.0"
   },


### PR DESCRIPTION
原因是VITE打包生成代码中有行：`process.env.NODE_ENV==="production"` 问题点重现方式：访问playgrounds/html/index.html

https://cdn.jsdelivr.net/npm无法访问的话可替换为https://unpkg.com

ref: https://blog.csdn.net/freedomlulux/article/details/130319155