### PR TITLE
perf: 分页样式优化

### DIFF
--- a/packages/components/table/index.tsx
+++ b/packages/components/table/index.tsx
@@ -145,6 +145,7 @@ export default defineComponent({
           width: "100%",
           margin: "16px 0",
           display: "flex",
+          flexWrap: "wrap",
           justifyContent:
             unref(pagination).align === "left"
               ? "flex-start"


### PR DESCRIPTION
分页情况下，移动端分页样式bug，导致分页展示不完整，如下图
![image](https://github.com/pure-admin/pure-admin-table/assets/54719786/d8026c62-3871-47bf-a14f-7ab2671bc2b7)

修复后展示完整，如下
![image](https://github.com/pure-admin/pure-admin-table/assets/54719786/d546fde7-fdb3-4d28-9369-a4687ccccd26)
